### PR TITLE
Add support for matching scripts and CSS to specific domain paths

### DIFF
--- a/Source/Extension/SafariExtensionHandler.swift
+++ b/Source/Extension/SafariExtensionHandler.swift
@@ -16,8 +16,9 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
 
         page.getPropertiesWithCompletionHandler {
             guard let host = $0?.url?.host else { return }
+            guard let path = $0?.url?.path else { return }
 
-            let basenames = fileBasenames(forHost: host)
+            let basenames = fileBasenames(forHost: host, forPath: path)
 
             let keysWithValues = Config.FileType.allCases.map { fileType -> (Type, [Name: Content]) in
                 let files: [Name: Content]
@@ -51,14 +52,20 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
     }
 }
 
-private func fileBasenames(forHost host: String) -> [String] {
-    let parts = host.split(separator: ".")
+private func fileBasenames(forHost host: String, forPath path: String) -> [String] {
+    let hostParts = host.split(separator: ".")
+    let pathParts = path.split(separator: "/")
+
     var baseNames = [String]()
-    for index in parts.startIndex ..< parts.endIndex {
-        baseNames.append(parts[index...].joined(separator: "."))
+    for index in hostParts.startIndex ..< hostParts.endIndex {
+        baseNames.append(hostParts[index...].joined(separator: "."))
     }
     baseNames.append("default")
     baseNames.reverse()
+
+    for index in pathParts.startIndex ..< pathParts.endIndex {
+        baseNames.append("\(host)/\(pathParts[...index].joined(separator: "/"))")
+    }
 
     return baseNames
 }


### PR DESCRIPTION
Implemented this following [Witchcraft](https://luciopaiva.com/witchcraft/)'s example:

> ### Path segments
> 
> Starting with version 2.5.0, Witchcraft also tries to match path segments. For example, going to `https://github.com/luciopaiva/witchcraft` will yield the following sequence of script loading attempts:
> 
>   - `\_global.js`
>   - `\_global.css`
>   - `com.js`
>   - `com.css`
>   - `github.com.js`
>   - `github.com.css`
>   - `github.com/luciopaiva.js`
>   - `github.com/luciopaiva.css`
>   - `github.com/luciopaiva/witchcraft.js`
>   - `github.com/luciopaiva/witchcraft.css`
> 
> Notice that path segments are mapped to local folders in your scripts directory.
> 
> Also important to notice is that, if the host name begins with `www`, it must be part of the directory structure as well. This is important because modern browsers tend to hide the `www` part, giving the false impression that it is not there.